### PR TITLE
shell: don't hard-exit when no FAT32 disk is attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,16 @@ for the full rationale behind keeping these two axes separate.
   capture as well as the test script's own reading of them, the same
   "prove it for real" bar `net_rtl8139` itself was held to.
 
+### Fixed
+
+- The shell hard-exited with `shell: FAIL (no fs)` and never showed a
+  prompt at all when booted without a FAT32 disk attached -- the normal
+  outcome of the plain `-cdrom`-only QEMU invocation `make run` and every
+  released ISO document, since `fs_fat32` by design never registers
+  `"fs"` with no volume to serve. The shell now always starts; only
+  `read`/`edit`/`run` (the commands that actually need a filesystem)
+  report it's unavailable. (Issue #20)
+
 ## [26.07-alpha.2] - 2026-07-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -206,6 +206,58 @@ scheme), not any single crate's own SemVer -- the kernel and every
 userland crate keep versioning themselves independently in their own
 `Cargo.toml`/`CHANGELOG.md`.
 
+## Running a downloaded release
+
+A release only ships `zephyrlite-<tag>-i386.iso` -- the kernel and every
+default userland service, nothing else. You don't need this repository
+cloned or any of the [Prerequisites](#prerequisites) above to run it, just
+`qemu-system-i386` itself:
+
+```sh
+qemu-system-i386 -cdrom zephyrlite-<tag>-i386.iso -serial stdio
+```
+
+boots straight to the shell. Without a filesystem attached, that's a
+genuinely empty boot -- `fs_fat32` has no FAT32 volume to read, and by
+design never registers itself as `"fs"` when that's the case (see
+[userland/services/fs_fat32/README.md](userland/services/fs_fat32/README.md))
+-- so `read`/`edit`/`run` all say a filesystem isn't available; only
+`help` does anything.
+
+To get a real filesystem `fs_fat32` can serve, create a small FAT32 disk
+image on the host and attach it as a second IDE drive alongside the CD:
+
+```sh
+# 1. Create a 64 MiB FAT32 image (needs dosfstools' mkfs.vfat --
+#    `sudo apt-get install dosfstools` on Debian/Ubuntu; mtools' `mformat`
+#    is a drop-in substitute if you have that instead: `truncate -s 64M
+#    pcern-disk.img && mformat -i pcern-disk.img -F -v PCERNFS ::`).
+mkfs.vfat -F 32 -n PCERNFS -C pcern-disk.img 65536
+
+# 2. Boot the ISO with that image attached as the primary IDE drive.
+#    -boot d matters here: with a second drive present, QEMU's default
+#    boot order would otherwise try it (it has no bootloader on it)
+#    before the CD.
+qemu-system-i386 \
+    -cdrom zephyrlite-<tag>-i386.iso \
+    -boot d \
+    -drive file=pcern-disk.img,if=ide,index=0,format=raw \
+    -serial stdio
+```
+
+`pcern-disk.img` starts out empty -- `edit <name>` inside the shell can
+still create a brand-new file on it from nothing -- but to put existing
+files on it first, from the host before booting, use mtools' `mcopy`
+against the same image (e.g. `mcopy -i pcern-disk.img hello.txt
+::HELLO.TXT`); `fs_fat32` only understands plain 8.3 filenames (no long
+names), the same limit `mcopy` itself falls back to.
+
+This is the same one-file, one-drive shape `make disk`/`make run-disk`
+build for repo development (see [Building and running](#building-and-running)
+above), minus the GRUB-embedded boot code those need and this doesn't --
+the CD is still what actually boots here; this image is pure data,
+read and written through the exact same protocol either way.
+
 ## Repository layout
 
 ```

--- a/userland/bin/shell/CHANGELOG.md
+++ b/userland/bin/shell/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-07-05
+
+### Fixed
+
+- The shell refused to start at all when `fs_fat32` hadn't registered
+  `"fs"` with the name service -- which is the normal, documented outcome
+  of booting with no FAT32 disk attached (e.g. `make run`'s plain
+  `-cdrom`-only QEMU invocation, or a downloaded release ISO booted the
+  same way), not a failure of anything. `read`/`edit`/`run <file>` do
+  need `fs_fat32` and stay unavailable in that case, but `help` and the
+  prompt itself don't, so hard-exiting on a missing `"fs"` made the
+  entire shell inaccessible for no reason. The shell now starts
+  regardless, prints a one-line notice that `fs`-dependent commands are
+  unavailable, and only `read`/`edit`/`run` themselves report "no
+  filesystem available" if actually invoked. (Issue #20)
+
 ## [0.2.0] - 2026-07-03
 
 ### Added

--- a/userland/bin/shell/Cargo.lock
+++ b/userland/bin/shell/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.0"
 
 [[package]]
 name = "shell"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "libpcern",
 ]

--- a/userland/bin/shell/Cargo.toml
+++ b/userland/bin/shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shell"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [[bin]]

--- a/userland/bin/shell/src/main.rs
+++ b/userland/bin/shell/src/main.rs
@@ -68,7 +68,12 @@ fn print_help(console_slot: u32) {
 /// Prints a file's contents a sector at a time -- same read loop
 /// fs_client_test already exercises, just against whatever name the user
 /// typed instead of a fixed one.
-fn cmd_read(console_slot: u32, fs_slot: u32, name: &[u8]) {
+fn cmd_read(console_slot: u32, fs_slot: Option<u32>, name: &[u8]) {
+    let Some(fs_slot) = fs_slot else {
+        print(console_slot, b"read: no filesystem available\n");
+        return;
+    };
+
     let size = match libpcern::fs_open(fs_slot, MY_INBOX, name) {
         Some(s) => s,
         None => {
@@ -92,7 +97,12 @@ fn cmd_read(console_slot: u32, fs_slot: u32, name: &[u8]) {
 
 /// Loads a file (capped at one page, see the module doc comment) into
 /// `RUN_BUF_VIRT` and spawns it via `SYS_SPAWN_FROM_MEMORY`.
-fn cmd_run(console_slot: u32, fs_slot: u32, run_grant: u32, name: &[u8]) {
+fn cmd_run(console_slot: u32, fs_slot: Option<u32>, run_grant: u32, name: &[u8]) {
+    let Some(fs_slot) = fs_slot else {
+        print(console_slot, b"run: no filesystem available\n");
+        return;
+    };
+
     let size = match libpcern::fs_open(fs_slot, MY_INBOX, name) {
         Some(s) => s,
         None => {
@@ -142,14 +152,14 @@ pub extern "C" fn _start() -> ! {
 
     // fs_fat32 needs several IPC round trips of its own (connecting to
     // storage_ata, reading the BPB) before it registers "fs" -- retry
-    // rather than treating a too-early lookup as failure.
-    let fs_slot = match libpcern::lookup_name_retry(b"fs", MY_INBOX, 1000) {
-        Some(s) => s,
-        None => {
-            print(console_slot, b"shell: FAIL (no fs)\n");
-            libpcern::exit(1);
-        }
-    };
+    // rather than treating a too-early lookup as failure. Unlike
+    // `console`'s lookup above, a missing "fs" isn't fatal: fs_fat32
+    // deliberately never registers "fs" when no FAT32 volume is attached
+    // (see its README), which is the normal case for the plain `make
+    // run`/`-cdrom`-only boot path -- so `read`/`edit`/`run` just stay
+    // unavailable rather than the whole shell refusing to start (see
+    // issue #20).
+    let fs_slot = libpcern::lookup_name_retry(b"fs", MY_INBOX, 1000);
 
     let fs_grant = libpcern::mem_alloc(FS_BUF_VIRT);
     let console_grant = libpcern::mem_alloc(CONSOLE_BUF_VIRT);
@@ -159,7 +169,9 @@ pub extern "C" fn _start() -> ! {
         libpcern::exit(1);
     }
 
-    libpcern::fs_connect(fs_slot, fs_grant, MY_INBOX);
+    if let Some(fs_slot) = fs_slot {
+        libpcern::fs_connect(fs_slot, fs_grant, MY_INBOX);
+    }
 
     // Own dedicated endpoint for console line-ready notifications -- see
     // the module doc comment for why this can't be MY_INBOX.
@@ -173,7 +185,11 @@ pub extern "C" fn _start() -> ! {
     // per invocation would leak its 64 KiB every time `edit` is typed.
     let mut editor = Editor::new(EDITOR_BUF_VIRT);
 
-    print(console_slot, b"pCern shell -- type 'help' for commands\n> ");
+    print(console_slot, b"pCern shell -- type 'help' for commands\n");
+    if fs_slot.is_none() {
+        print(console_slot, b"shell: no fs (read/edit/run unavailable)\n");
+    }
+    print(console_slot, b"> ");
 
     loop {
         let len = libpcern::console_read_line(console_slot, reader_slot) as usize;
@@ -184,9 +200,12 @@ pub extern "C" fn _start() -> ! {
             b"help" => print_help(console_slot),
             b"read" => cmd_read(console_slot, fs_slot, argument),
             b"run" => cmd_run(console_slot, fs_slot, run_grant, argument),
-            b"edit" => match &mut editor {
-                Some(ed) => editor::run(console_slot, reader_slot, MY_INBOX, fs_slot, FS_BUF_VIRT, ed, argument),
-                None => print(console_slot, b"edit: unavailable (alloc failed at startup)\n"),
+            b"edit" => match (&mut editor, fs_slot) {
+                (Some(ed), Some(fs_slot)) => {
+                    editor::run(console_slot, reader_slot, MY_INBOX, fs_slot, FS_BUF_VIRT, ed, argument)
+                }
+                (None, _) => print(console_slot, b"edit: unavailable (alloc failed at startup)\n"),
+                (_, None) => print(console_slot, b"edit: no filesystem available\n"),
             },
             b"" => {}
             _ => {


### PR DESCRIPTION
## Summary

- `fs_fat32` deliberately never registers `"fs"` with the name service when no FAT32 volume is present (see its README) -- which is the normal outcome of `make run`'s plain `-cdrom`-only QEMU invocation, or any downloaded release ISO booted the same way (`qemu-system-i386 -cdrom <iso> -serial stdio`, no `-drive`). The shell treated that missing `"fs"` as fatal and called `exit(1)` before ever printing a prompt, so the whole shell was unusable even for commands (`help`) that don't touch a filesystem.
- The shell now always starts: it prints a one-line notice if `"fs"` isn't available, and only `read`/`edit`/`run` (the commands that actually need `fs_fat32`) report "no filesystem available" if invoked without one.
- Bumped `shell`'s own SemVer (0.2.0 -> 0.2.1) and added `Fixed` entries to both `shell/CHANGELOG.md` and the root `CHANGELOG.md`, per this repo's per-crate + OS-level changelog convention.

Fixes #20.

## Test plan

- [x] `make clean && make test` -- full regression suite (cap_test fixtures, keyboard/raw-input/editor/reboot/nic/arp tests, disk-boot test) passes with the fix in place.
- [x] `cargo build --release` for the `shell` crate builds cleanly.
- [x] Confirmed via code reading that `fs_fat32`/`storage_ata`'s no-disk behavior is unchanged and intentional; the fix only changes how `shell` reacts to it.
- [ ] Did not manage to directly observe the exact reported "no disk, `-cdrom`-only boot" scenario end-to-end in this sandbox: without hardware acceleration (no `/dev/kvm`), the affected boot path's software-only QEMU emulation didn't resolve even after 150s, so I couldn't screendump the new startup notice live. The fix is a small, direct change to the exact code path identified as the cause, and is covered by the reasoning above plus the full regression suite passing unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DXDaXFnE6ajj3uA6hjWksg)_